### PR TITLE
Merchant to do list

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,7 +6,6 @@ class Item < ApplicationRecord
 
   validates_presence_of :name,
                         :description,
-                        :image,
                         :price,
                         :inventory
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -21,6 +21,10 @@ class Item < ApplicationRecord
     .limit(limit)
   end
 
+  def self.unfulfilled_count
+    joins(:order_items).where("order_items.fulfilled = false").count
+  end
+
   def sorted_reviews(limit = nil, order = :asc)
     reviews.order(rating: order).limit(limit)
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -25,6 +25,11 @@ class Item < ApplicationRecord
     joins(:order_items).where("order_items.fulfilled = false").count
   end
 
+  def self.unfulfilled_total_price
+    joins(:order_items).where("order_items.fulfilled = false")
+                      .sum("order_items.price * order_items.quantity")
+  end
+
   def sorted_reviews(limit = nil, order = :asc)
     reviews.order(rating: order).limit(limit)
   end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -35,6 +35,6 @@ class Merchant < ApplicationRecord
   end
 
   def items_missing_images
-    items.where(image: nil)
+    items.where(image: [nil, ''])
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -33,4 +33,8 @@ class Merchant < ApplicationRecord
   def order_items_by_order(order_id)
     order_items.where(order_id: order_id)
   end
+
+  def items_missing_images
+    items.where(image: nil)
+  end
 end

--- a/app/views/merchant/dashboard/index.html.erb
+++ b/app/views/merchant/dashboard/index.html.erb
@@ -24,4 +24,7 @@
       <div><%= link_to "#{item.name}", edit_merchant_item_path(item.id) %></div>
     <% end %>
   </section>
+  <section class="unfulfilled-items">
+    <h3>You have <%= @merchant.items.unfulfilled_count %> unfulfilled orders worth <%= number_to_currency(@merchant.items.unfulfilled_total_price) %></h3>
+  </section>
 </section>

--- a/app/views/merchant/dashboard/index.html.erb
+++ b/app/views/merchant/dashboard/index.html.erb
@@ -15,3 +15,13 @@
     </section>
   <% end %>
 </section>
+
+<section class="to-do-list">
+  <h2>To-Do-List:</h2>
+  <section class="items-missing-images">
+    <h3>Items missing images:</h3>
+    <% @merchant.items_missing_images do |item| %>
+      <p><%= link_to "#{item.name}", edit_merchant_item_path(item.id) %></p>
+    <% end %>
+  </section>
+</section>

--- a/app/views/merchant/dashboard/index.html.erb
+++ b/app/views/merchant/dashboard/index.html.erb
@@ -20,8 +20,8 @@
   <h2>To-Do-List:</h2>
   <section class="items-missing-images">
     <h3>Items missing images:</h3>
-    <% @merchant.items_missing_images do |item| %>
-      <p><%= link_to "#{item.name}", edit_merchant_item_path(item.id) %></p>
+    <% @merchant.items_missing_images.each do |item| %>
+      <div><%= link_to "#{item.name}", edit_merchant_item_path(item.id) %></div>
     <% end %>
   </section>
 </section>

--- a/spec/features/merchant/edit_item_spec.rb
+++ b/spec/features/merchant/edit_item_spec.rb
@@ -52,7 +52,6 @@ RSpec.describe 'Update Item Page' do
 
       expect(page).to have_content("description: [\"can't be blank\"]")
       expect(page).to have_content("price: [\"can't be blank\"]")
-      expect(page).to have_content("image: [\"can't be blank\"]")
       expect(page).to have_content("inventory: [\"can't be blank\"]")
       expect(page).to have_button('Update Item')
     end

--- a/spec/features/merchant/new_item_spec.rb
+++ b/spec/features/merchant/new_item_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe 'New Merchant Item' do
 
       expect(page).to have_content("description: [\"can't be blank\"]")
       expect(page).to have_content("price: [\"can't be blank\"]")
-      expect(page).to have_content("image: [\"can't be blank\"]")
       expect(page).to have_content("inventory: [\"can't be blank\"]")
       expect(page).to have_button('Create Item')
     end

--- a/spec/features/merchant/to_do_spec.rb
+++ b/spec/features/merchant/to_do_spec.rb
@@ -20,9 +20,8 @@ RSpec.describe 'Merchant Dashboard' do
 
     it "I can see a to do list of items without images" do
       visit "/merchant"
-
-      within "#to-do-list" do
-        within "#items-missing-images" do
+      within ".to-do-list" do
+        within ".items-missing-images" do
           expect(page).to have_content(@giant.name)
           click_link(@ogre.name)
         end

--- a/spec/features/merchant/to_do_spec.rb
+++ b/spec/features/merchant/to_do_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Merchant Dashboard' do
       visit "/merchant"
       within ".to-do-list" do
         within ".unfulfilled-items" do
-          expect(page).to have_content("You have 5 unfulfilled orders worth $140.50")
+          expect(page).to have_content("You have 3 unfulfilled orders worth $240.50")
         end
       end
     end

--- a/spec/features/merchant/to_do_spec.rb
+++ b/spec/features/merchant/to_do_spec.rb
@@ -29,6 +29,15 @@ RSpec.describe 'Merchant Dashboard' do
       expect(current_path).to eq(edit_merchant_item_path(@hippo.id))
     end
 
+    it "I can see a count of unfulfilled items and their total cost" do
+      visit "/merchant"
+      within ".to-do-list" do
+        within ".unfulfilled-items" do
+          expect(page).to have_content("You have 5 unfulfilled orders worth $140.50")
+        end
+      end
+    end
+
 
   end
 end

--- a/spec/features/merchant/to_do_spec.rb
+++ b/spec/features/merchant/to_do_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'Merchant Dashboard' do
+  describe 'As an employee of a merchant' do
+    before :each do
+      @merchant_1 = Merchant.create!(name: 'Megans Marmalades', address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218)
+      @m_user = @merchant_1.users.create(name: 'Megan', address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218, email: 'megan@example.com', password: 'securepassword')
+      @ogre = @merchant_1.items.create!(name: 'Ogre', description: "I'm an Ogre!", price: 20.25, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 5 )
+      @giant = @merchant_1.items.create!(name: 'Giant', description: "I'm a Giant!", price: 50, active: true, inventory: 3 )
+      @hippo = @merchant_1.items.create!(name: 'Hippo', description: "I'm a Hippo!", price: 50, active: true, inventory: 1 )
+      @order_1 = @m_user.orders.create!(status: "pending")
+      @order_2 = @m_user.orders.create!(status: "pending")
+      @order_3 = @m_user.orders.create!(status: "pending")
+      @order_item_1 = @order_1.order_items.create!(item: @hippo, price: @hippo.price, quantity: 2, fulfilled: false)
+      @order_item_2 = @order_2.order_items.create!(item: @hippo, price: @hippo.price, quantity: 2, fulfilled: true)
+      @order_item_3 = @order_2.order_items.create!(item: @ogre, price: @ogre.price, quantity: 2, fulfilled: false)
+      @order_item_4 = @order_3.order_items.create!(item: @giant, price: @giant.price, quantity: 2, fulfilled: false)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@m_user)
+    end
+
+    it "I can see a to do list of items without images" do
+      visit "/merchant"
+
+      within "#to-do-list" do
+        within "#items-missing-images" do
+          expect(page).to have_content(@giant.name)
+          click_link(@ogre.name)
+        end
+      end
+      expect(current_path).to eq(edit_merchant_item_path(@ogre.id))
+    end
+
+
+  end
+end

--- a/spec/features/merchant/to_do_spec.rb
+++ b/spec/features/merchant/to_do_spec.rb
@@ -23,10 +23,10 @@ RSpec.describe 'Merchant Dashboard' do
       within ".to-do-list" do
         within ".items-missing-images" do
           expect(page).to have_content(@giant.name)
-          click_link(@ogre.name)
+          click_link(@hippo.name)
         end
       end
-      expect(current_path).to eq(edit_merchant_item_path(@ogre.id))
+      expect(current_path).to eq(edit_merchant_item_path(@hippo.id))
     end
 
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Item do
   describe 'Validations' do
     it {should validate_presence_of :name}
     it {should validate_presence_of :description}
-    it {should validate_presence_of :image}
     it {should validate_presence_of :price}
     it {should validate_presence_of :inventory}
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -68,8 +68,8 @@ RSpec.describe Item do
       @order_2 = @user.orders.create!
       @order_3 = @user.orders.create!
       @order_1.order_items.create!(item: @ogre, price: @ogre.price, quantity: 2)
-      @order_1.order_items.create!(item: @hippo, price: @hippo.price, quantity: 3)
-      @order_2.order_items.create!(item: @hippo, price: @hippo.price, quantity: 5)
+      @order_1.order_items.create!(item: @hippo, price: @hippo.price, quantity: 3, fulfilled: true)
+      @order_2.order_items.create!(item: @hippo, price: @hippo.price, quantity: 5, fulfilled: true)
       @order_3.order_items.create!(item: @nessie, price: @nessie.price, quantity: 7)
       @order_3.order_items.create!(item: @gator, price: @gator.price, quantity: 1)
     end
@@ -82,6 +82,10 @@ RSpec.describe Item do
       expect(Item.by_popularity).to eq([@hippo, @nessie, @ogre, @gator, @giant])
       expect(Item.by_popularity(3, "ASC")).to eq([@giant, @gator, @ogre])
       expect(Item.by_popularity(3, "DESC")).to eq([@hippo, @nessie, @ogre])
+    end
+
+    it '.unfulfilled_count' do
+      expect(Item.unfulfilled_count).to eq(3)
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -87,5 +87,9 @@ RSpec.describe Item do
     it '.unfulfilled_count' do
       expect(Item.unfulfilled_count).to eq(3)
     end
+
+    it ".unfulfilled_total_price" do
+      expect(Item.unfulfilled_total_price).to eq(440)
+    end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Merchant do
       @brian = Merchant.create!(name: 'Brians Bagels', address: '125 Main St', city: 'Denver', state: 'CO', zip: 80218)
       @sal = Merchant.create!(name: 'Sals Salamanders', address: '125 Main St', city: 'Denver', state: 'CO', zip: 80218)
       @ogre = @megan.items.create!(name: 'Ogre', description: "I'm an Ogre!", price: 20.25, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 5 )
-      @giant = @megan.items.create!(name: 'Giant', description: "I'm a Giant!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 3 )
-      @hippo = @brian.items.create!(name: 'Hippo', description: "I'm a Hippo!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 3 )
+      @giant = @megan.items.create!(name: 'Giant', description: "I'm a Giant!", price: 50, active: true, inventory: 3 )
+      @hippo = @brian.items.create!(name: 'Hippo', description: "I'm a Hippo!", price: 50, active: true, inventory: 3 )
       @user_1 = User.create!(name: 'Megan', address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218, email: 'megan_1@example.com', password: 'securepassword')
       @user_2 = User.create!(name: 'Megan', address: '123 Main St', city: 'Denver', state: 'IA', zip: 80218, email: 'megan_2@example.com', password: 'securepassword')
       @order_1 = @user_1.orders.create!
@@ -56,6 +56,11 @@ RSpec.describe Merchant do
 
     it '.order_items_by_order' do
       expect(@megan.order_items_by_order(@order_1.id)).to eq([@order_item_1])
+    end
+
+    it ".items_missing_images" do
+      expect(@megan.items_missing_images).to eq([@giant])
+      expect(@brian.items_missing_images).to eq([@hippo])
     end
   end
 end


### PR DESCRIPTION
Adds the first half of the merchant to-do-list extension.
Merchants can view a to-do-list on their dashboard and it has a list of items without an image as well as a count of unfulfilled item orders with the total price of those orders.